### PR TITLE
Fix css auto gen on admin dashboard

### DIFF
--- a/src/public/admin-font-edit.html
+++ b/src/public/admin-font-edit.html
@@ -156,6 +156,15 @@
 
 						<div class="actions">
 							<button type="submit">儲存修改</button>
+							<button
+								id="font-regenerate-button"
+								data-super-admin-only
+								type="button"
+								disabled
+								hidden
+							>
+								重新生成字型與 CSS
+							</button>
 							<a
 								id="font-preview-link"
 								class="text-link"

--- a/src/public/assets/admin-font-edit.js
+++ b/src/public/assets/admin-font-edit.js
@@ -9,6 +9,7 @@ const demoSentenceSelect = document.getElementById("demo-sentence-select");
 const sentenceCreateForm = document.getElementById("sentence-create-form");
 const logoutButton = document.getElementById("admin-logout");
 const deleteButton = document.getElementById("font-delete-button");
+const regenerateButton = document.getElementById("font-regenerate-button");
 
 let fontList = [];
 let demoSentences = [];
@@ -124,6 +125,7 @@ function fillForm(font) {
 	previewLink.href = font.fontUrl;
 	editForm.hidden = false;
 	deleteButton.disabled = !isSuperAdmin();
+	regenerateButton.disabled = !isSuperAdmin();
 	renderFontList();
 }
 
@@ -203,6 +205,7 @@ async function refreshAfterDelete(fontId) {
 	selectedFontId = "";
 	editForm.hidden = true;
 	deleteButton.disabled = true;
+	regenerateButton.disabled = true;
 	previewLink.href = "#";
 	await loadFontList();
 	setStatus(`已刪除 ${fontId}`, "completed");
@@ -323,6 +326,36 @@ deleteButton.addEventListener("click", async () => {
 	} catch (error) {
 		setStatus(error.message, "failed");
 		deleteButton.disabled = !isSuperAdmin();
+	}
+});
+
+regenerateButton.addEventListener("click", async () => {
+	if (!selectedFontId) return;
+	const fontId = selectedFontId;
+	if (!window.confirm(`要重新生成 ${fontId} 的靜態字型、CSS 並切換版號嗎？`))
+		return;
+	regenerateButton.disabled = true;
+	setStatus("正在重新生成");
+	try {
+		const res = await fetch(
+			`/api/admin/fonts/${encodeURIComponent(fontId)}/regenerate`,
+			{
+				method: "POST",
+				headers: headers(),
+				body: JSON.stringify({}),
+			},
+		);
+		if (redirectIfUnauthorized(res)) return;
+		const data = await res.json();
+		if (!res.ok) throw new Error(data.message || "Regenerate failed");
+		const job = await pollJob(data.jobId);
+		if (job?.status === "failed")
+			throw new Error(job.error || "Regeneration failed");
+		setStatus("字型已重新生成，CSS 已更新", "completed");
+	} catch (error) {
+		setStatus(error.message, "failed");
+	} finally {
+		regenerateButton.disabled = !isSuperAdmin();
 	}
 });
 

--- a/src/public/assets/admin-font-edit.js
+++ b/src/public/assets/admin-font-edit.js
@@ -332,8 +332,7 @@ deleteButton.addEventListener("click", async () => {
 regenerateButton.addEventListener("click", async () => {
 	if (!selectedFontId) return;
 	const fontId = selectedFontId;
-	if (!window.confirm(`要重新生成 ${fontId} 的靜態字型、CSS 並切換版號嗎？`))
-		return;
+	if (!window.confirm(`要重新生成 ${fontId} 的靜態字型和 CSS 嗎？`)) return;
 	regenerateButton.disabled = true;
 	setStatus("正在重新生成");
 	try {

--- a/src/website/admin.js
+++ b/src/website/admin.js
@@ -15,6 +15,7 @@ import { logger } from "../utils/logger.js";
 import { analyseFontsInBatches } from "../utils/read-font-file/analyseFonts.js";
 import { get_bullet, get_generated_static_floders } from "../bootstrap/init.js";
 import { regenerateAllStaticFont } from "../bootstrap/fontNoMin.js";
+import { generateCSSMap } from "./generateCSSMap.js";
 
 const redis = new Redis(process.env.REDIS_URL);
 const uploadJobs = new Map();
@@ -456,6 +457,24 @@ async function syncGeneratedStaticFontToMinio({ id, weight, version }) {
 	);
 }
 
+async function syncCssToMinio({ id, weight, css }) {
+	if (process.env.SYNC_WITH_MINIO !== "true") return;
+	if (!isMinioConfigured()) {
+		throw new Error("SYNC_WITH_MINIO=true, but MinIO is not configured");
+	}
+	const minioClient = createMinioClient();
+	const key = `css/${id}/${weight}.css`;
+	await minioClient.send(
+		new PutObjectCommand({
+			Bucket: process.env.MINIO_BUCKET,
+			Key: key,
+			Body: css,
+			ContentType: "text/css; charset=utf-8",
+		}),
+	);
+	logger.info(`Synced CSS to MinIO: ${key}`);
+}
+
 async function saveOriginalFontFile({ id, weight, extension, fileBase64 }) {
 	if (process.env.SYNC_WITH_MINIO === "true" && !isMinioConfigured()) {
 		throw new Error("SYNC_WITH_MINIO=true, but MinIO is not configured");
@@ -803,17 +822,17 @@ async function createDemoSentence(body) {
 }
 
 async function generateStaticForUploadedFont(job, font) {
+	const weights = font.weights?.length ? font.weights : [font.weight];
 	job.status = "running";
 	job.message = "正在分析字型支援的語言";
-	await analyseFontsInBatches([
-		{
-			fontName: font.id,
-			weights: String(font.weight),
-		},
-	]);
+	await analyseFontsInBatches(
+		weights.map(weight => ({ fontName: font.id, weights: String(weight) })),
+	);
 
 	job.message = "正在切割靜態字型包";
-	await removeStaticFontPackages(font.id, font.weight);
+	for (const weight of weights) {
+		await removeStaticFontPackages(font.id, weight);
+	}
 	const ok = await regenerateAllStaticFont(
 		job.state,
 		await get_generated_static_floders(),
@@ -824,14 +843,23 @@ async function generateStaticForUploadedFont(job, font) {
 	const staticFontVersion = await get_bullet();
 	job.state.static_font_version = staticFontVersion;
 	job.message = "正在同步靜態字型到 MinIO";
-	await syncGeneratedStaticFontToMinio({
-		id: font.id,
-		weight: font.weight,
-		version: staticFontVersion,
-	});
+	for (const weight of weights) {
+		await syncGeneratedStaticFontToMinio({
+			id: font.id,
+			weight,
+			version: staticFontVersion,
+		});
+	}
+	job.message = "正在生成並上傳 CSS";
+	for (const weight of weights) {
+		const css = await generateCSSMap(font.id, weight, job.state);
+		await syncCssToMinio({ id: font.id, weight, css });
+	}
 	await redis.del(`fontinfo:${font.id}`);
 	job.status = "completed";
-	job.message = "字型已新增，靜態字型也切好了";
+	job.message = font.weights
+		? "字型已重新生成，CSS 已更新"
+		: "字型已新增，靜態字型與 CSS 都切好了";
 	job.completedAt = new Date().toISOString();
 }
 
@@ -866,9 +894,9 @@ function queueStaticGenerationJob({ state, font, queuedMessage }) {
 	uploadJobs.set(jobId, job);
 
 	generateStaticForUploadedFont(job, font).catch(error => {
-		logger.error(`Admin font upload job failed: ${error.message}`);
+		logger.error(`Admin font job failed: ${error.message}`);
 		job.status = "failed";
-		job.message = "靜態字型切割失敗";
+		job.message = "字型處理失敗";
 		job.error = error.message;
 		job.completedAt = new Date().toISOString();
 	});
@@ -1089,6 +1117,31 @@ export default async function registerAdmin(app, state) {
 				status: "success",
 				message: "Font deleted",
 				fontId: req.params.fontId,
+			});
+		} catch (error) {
+			res.status(400).send({ status: "failed", message: error.message });
+		}
+	});
+
+	app.post("/api/admin/fonts/:fontId/regenerate", async (req, res) => {
+		if (!(await requireSuperAdminApi(req, res))) return;
+		try {
+			const font = await getFontRecord(req.params.fontId);
+			if (!font) {
+				return res
+					.status(404)
+					.send({ status: "failed", message: "Font not found" });
+			}
+			const jobId = queueStaticGenerationJob({
+				state,
+				font: { id: font.id, weights: font.weights || [] },
+				queuedMessage: "已排入重新生成佇列，等待切割靜態字型",
+			});
+			res.status(202).send({
+				status: "accepted",
+				message: "Font regeneration started.",
+				jobId,
+				fontUrl: fontInfoUrl(state, font.id),
 			});
 		} catch (error) {
 			res.status(400).send({ status: "failed", message: error.message });

--- a/src/website/generateCSSMap.js
+++ b/src/website/generateCSSMap.js
@@ -66,7 +66,7 @@ async function generateCSSMap(font_id, weight, state) {
 	});
 
 	writeCssFile(font_id, weight, cssBlocks, state);
-	return cssBlocks;
+	return cssBlocks.join("");
 }
 
 export { generateCSSMap };

--- a/src/website/generateCSSMap.js
+++ b/src/website/generateCSSMap.js
@@ -65,8 +65,9 @@ async function generateCSSMap(font_id, weight, state) {
   }\n`;
 	});
 
-	writeCssFile(font_id, weight, cssBlocks, state);
-	return cssBlocks.join("");
+	const joinedCss = cssBlocks.join("");
+	await writeCssFile(font_id, weight, joinedCss);
+	return joinedCss;
 }
 
 export { generateCSSMap };


### PR DESCRIPTION
- 修復管理介面上傳字型後不會生成 css  #120 
- 同時增加重新生成 css 和靜態字型的按鈕，用於補救過去已上傳的字型

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 超级管理员可在字体编辑页面重新生成字体及 CSS。
  * 支持按字体全部权重重新生成静态字体文件，并同步相关资源。
  * 新增生成任务状态轮询，完成后显示成功或失败结果。
* **改进**
  * 生成过程中按钮自动禁用，并根据权限恢复可用状态。
  * 优化字体加载、删除及表单初始化时的操作状态提示。
  * 改进 CSS 资源生成与同步流程，提升字体资源更新的一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->