### PR TITLE
feat: add I.Ming (一點明體) font family metadata

### DIFF
--- a/migrates/005.do.insert-iming.sql
+++ b/migrates/005.do.insert-iming.sql
@@ -1,0 +1,35 @@
+-- 一點明體 I.Ming https://github.com/ichitenfont/I.Ming
+-- weights 留空，等原始字型檔 (8.10/I.Ming-8.10.ttf -> IMing/400.ttf) 上傳後由 init / admin upload 補上
+INSERT INTO font_family (
+    id, name, name_zh, name_en, weights, license, version, description,
+    category, family, tags, repo_url, authors, format, languages, demo_content_id
+) VALUES (
+    'IMing',
+    'I.Ming',
+    '一點明體',
+    'I.Ming',
+    ARRAY[]::smallint[],
+    'IPA Font License 1.0',
+    '8.10',
+    '一點明體（I.明體）是一點字坊依照傳承字形標準化文件《傳承字形部件檢校表》推薦字形製作的開源明體，前身為 IPAmj 明朝。收錄超過六萬字，覆蓋 Big5、GB2312、IICore、《通用規範漢字表》與《常用香港外字表》等字集，適合正體中文長文排版。',
+    'serif',
+    'IPAmj Mincho',
+    ARRAY['明體', '傳承字形']::text[],
+    'https://github.com/ichitenfont/I.Ming',
+    ARRAY['一點字坊 ichitenfont']::text[],
+    'ttf',
+    '{
+      "Common":1346,
+      "Latin":563,
+      "Bopomofo":77,
+      "Inherited":50,
+      "Greek":80,
+      "Cyrillic":98,
+      "Han":57124,
+      "Hiragana":375,
+      "Katakana":299,
+      "private_area":5
+    }'::json,
+    1
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## 摘要

新增「一點明體 I.Ming」（https://github.com/ichitenfont/I.Ming）的 `font_family` 資料到 migration `005.do.insert-iming.sql`。

原始字型檔無法透過 PR 進 repo（原始字型放在 MinIO），所以這個 PR 只補 metadata，並把 `weights` 留空 —— 在檔案上傳前 `/g/IMing` 會走既有的 503「Font missing」路徑，不會出錯。

## 上線需要的手動步驟

1. 下載 [`8.10/I.Ming-8.10.ttf`](https://github.com/ichitenfont/I.Ming/raw/master/8.10/I.Ming-8.10.ttf)（約 25 MB、60597 glyphs，單一字重 400）
2. 重新命名為 `IMing/400.ttf` 放進 MinIO 的 `original-fonts/`，或直接用 admin 上傳頁以 id `IMing`、字重 400 上傳；admin 上傳會 upsert 這筆資料並補上 `weights`，再自動切靜態字型與 CSS

## 資料說明

- `languages` 欄位是用 repo 內的 `ScriptFinder` 對實際 TTF 的 cmap 統計出來的（Han 57124、Common 1346、Latin 563…）
- 授權是 **IPA Font License 1.0**，不是 OFL；I.Ming 是 IPAmj 明朝的衍生字型，`family` 填 `IPAmj Mincho`
- 同系列還有 I.MingCP / I.MingVar / I.MingVarCP / PMingI.U / PMingI.UVar，這次只加主字型，之後有需要可以同樣方式補

## 檢查

- `ON CONFLICT (id) DO NOTHING`，如果已經先用 admin 上傳過，migration 不會覆蓋

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增「一點明體（I.Ming）」字体。
  - 提供字体的版本、许可证、分类、标签、作者、格式及语言覆盖等信息。
  - 新增字体演示内容，方便用户预览使用效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->